### PR TITLE
Enable muli-platform docker images

### DIFF
--- a/.github/workflows/docker-build-deploy.yml
+++ b/.github/workflows/docker-build-deploy.yml
@@ -61,7 +61,5 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64,linux/arm64,linux/arm/v7 
-          build-args: 
-          builder: ${{ steps.buildx.outputs.name }} 
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/docker-build-deploy.yml
+++ b/.github/workflows/docker-build-deploy.yml
@@ -30,6 +30,7 @@ jobs:
       - uses: actions/checkout@v4
       
       - name: Set up Docker Buildx
+        id: buildx
         uses: docker/setup-buildx-action@v3
       
       - name: Docker meta
@@ -59,5 +60,8 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64,linux/arm/v7 
+          build-args: 
+          builder: ${{ steps.buildx.outputs.name }} 
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
Right now your addon doesn't support ARM so new Macs, Raspberry Pi etc. I've added lines to enable multi platform docker image creating